### PR TITLE
Frontend: Fixed navigation bar

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -1,5 +1,5 @@
 # The primary navigation
-ospo:
+codegov:
   - name: Overview
     url: /
   - name: Agencies

--- a/content/agencies/index.md
+++ b/content/agencies/index.md
@@ -3,12 +3,12 @@ title: Agencies
 description: 'Agencies'
 permalink: /agencies/
 layout: layouts/page
-tags: agencies
-# eleventyNavigation:
-#   parent: ospo-inbound
-#   key: ospo-inbound-main
-#   order: 1
-#   title: Inbound
+tags: codegov
+eleventyNavigation:
+  parent: codegov-agencies
+  key: codegov-agencies-main
+  order: 1
+  title: Agencies
 sidenav: false
 sticky_sidenav: false
 ---

--- a/content/guidance/index.md
+++ b/content/guidance/index.md
@@ -3,7 +3,7 @@ title: Guidance
 description: 'Guidance'
 permalink: /guidance/
 layout: layouts/page
-tags: guidance
+tags: codegov
 eleventyNavigation:
   parent: codegov-guidance
   key: codegov-guidance-main

--- a/content/guidance/inventory-code.md
+++ b/content/guidance/inventory-code.md
@@ -3,7 +3,7 @@ title: Creating your enterprise code inventory
 description: 'Code Inventory'
 permalink: /guidance/code-inventory
 layout: layouts/page
-tags: guidance
+tags: codegov
 eleventyNavigation:
   parent: codegov-guidance
   key: codegov-guidance-codeinventory

--- a/content/guidance/procurement.md
+++ b/content/guidance/procurement.md
@@ -3,7 +3,7 @@ title: Building and Buying Custom Software
 description: 'Procurement'
 permalink: /guidance/procurement
 layout: layouts/page
-tags: guidance
+tags: codegov
 eleventyNavigation:
   parent: codegov-guidance
   key: codegov-guidance-procurement

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 permalink: /
 layout: layouts/default
 title: Home
-tags: ospo
+tags: codegov
 eleventyNavigation:
   parent: codegov
   key: codegov-home


### PR DESCRIPTION
## Frontend: Fixed nav

## Problem

The navigation bar only shows up in the home page and does not appear in section pages.

## Solution

Fixed nav by updating tags in all pages to use `codegov` so all pages live under eleventyNavigation dictionary

## Result

Navigation bar shows up in all pages
<img width="935" alt="Screenshot 2025-05-01 at 12 25 40 PM" src="https://github.com/user-attachments/assets/b6363ffd-a9cd-4f04-8561-9ea10585f79c" />


## Test Plan

```
npm install
npm run dev
```