### PR TITLE
Add Download Job

### DIFF
--- a/.github/workflows/fetchAgencyCodeJSON.yml
+++ b/.github/workflows/fetchAgencyCodeJSON.yml
@@ -1,0 +1,43 @@
+name: fetchAgencyCodeJSON
+
+on:
+    schedule:
+            # Run mondays at 7:15 am
+            - cron: "15 7 * * 0"
+    workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+    update:
+        permissions: write-all
+        name: update
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
+              with: 
+                python-version: '3.13'
+            - name: cache pip
+              uses: actions/cache@v4
+              with: 
+                path: ~/.cache/pip
+                key: ${{ runner.os }}-pip-${{ hashFiles('scripts/requirements.txt') }}
+                restore-keys: |
+                  ${{ runner.os }}-pip-
+            - run: pip install -r scripts/requirements.txt
+            - run: python scripts/pull-public-assets.py
+            - run: |
+                git config user.name 'GitHub Actions'
+                git config user.email 'actions@users.noreply.github.com'
+                git pull
+                git add -A
+                timestamp=$(date -u)
+                git commit -m "update codejson data: ${timestamp}" || exit 0
+            - name: Push to ${{ github.ref_name }}
+              uses: CasperWA/push-protected@v2
+              with:
+                branch: ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ web_modules/
 .env.test.local
 .env.production.local
 .env.local
+.venv/
 
 # VSCode files, e.g. launch configuration
 .vscode

--- a/codegov.json
+++ b/codegov.json
@@ -1,6 +1,7 @@
 {
   "GSA": {
     "agency": "GSA",
+    "orgs": ["uswds","GSA","18F"],
     "version": "1.0.0",
     "measurementType": {
       "method": "projects"
@@ -306,6 +307,7 @@
   },
   "HHS": {
     "agency": "HHS",
+    "orgs": ["DSACMS"],
     "version": "1.0.0",
     "measurementType": {
       "method": "projects"

--- a/scripts/pull-public-assets.py
+++ b/scripts/pull-public-assets.py
@@ -1,61 +1,44 @@
 import json
-import base64
-import argparse
 import os
 
 from codejson_index_generator import IndexGenerator
 
 AGENCY_CODEJSON_DIR = "agency-indexes"
+VERSION = '0.0.1'
 
 def main():
-    parser = argparse.ArgumentParser(
-        description = "Create an index of code.json files within agency organizations for code.gov compliance.",
-        epilog = "Examples:"
-               "  python pull-public-assets.py --agency CMS --orgs 'org1,org2' --OR-- "
-               "  python pull-public-assets.py --agency TTS --orgs 'GSA,USDC' --version 2.0.0"
-    )
+    
 
-    parser.add_argument(
-        "--agency", 
-        required = True,
-        help = "Agency name for code.json index creation"
-    )
-    parser.add_argument(
-        "--orgs", 
-        required = True,
-        help = "Comma-separated list of GitHub organizations in your agency"
-    )
+    with open('codegov.json','r') as file:
+        codegovDict = json.load(file)
 
-    parser.add_argument(
-        "--version", 
-        default = "1.0.0",
-        help = "Code.json file version (e.g., 1.0.0, 2.1.0)"
-    )
-
-    args = parser.parse_args()
     github_key = os.getenv("GITHUB_KEY")
 
     try:
-        indexGen = IndexGenerator(
-            agency = args.agency,
-            verison = args.version, 
-            token = github_key
-        )
+        for agency in codegovDict.keys():
 
-        agency_dir = os.path.join(AGENCY_CODEJSON_DIR, args.agency)
-        try:
-            os.mkdir(agency_dir)
-        except FileExistsError:
-            print(f"File already exists: {agency_dir}")
+            
+            indexGen = IndexGenerator(
+                agency = agency,
+                verison = VERSION, 
+                token = github_key
+            )
 
-        for org in args.orgs.split(","):
-            org = org.strip()
-            indexGen.process_organization(org)
+            agency_dir = os.path.join(AGENCY_CODEJSON_DIR, agency)
+            try:
+                os.mkdir(agency_dir)
+            except FileExistsError:
+                print(f"File already exists: {agency_dir}")
 
-            indexGen.save_organization_files(org, agency_dir)
+            orgs = codegovDict[agency]["orgs"]
+            for org in orgs:
+                org = org.strip()
+                indexGen.process_organization(org)
 
-        indexGen.save_index(os.path.join(agency_dir, args.agency, "_index.json"))
-        print(f"\nIndexing complete. Results saved to {agency_dir}")
+                indexGen.save_organization_files(org, agency_dir)
+
+            indexGen.save_index(os.path.join(agency_dir, agency, "_index.json"))
+            print(f"\nIndexing complete. Results saved to {agency_dir}")
         
     except Exception as e:
         print(f"Error: {e}")

--- a/scripts/pull-public-assets.py
+++ b/scripts/pull-public-assets.py
@@ -12,7 +12,7 @@ def main():
     with open('codegov.json','r') as file:
         codegovDict = json.load(file)
 
-    github_key = os.getenv("GITHUB_KEY")
+    github_key = os.getenv("GITHUB_TOKEN")
 
     try:
         for agency in codegovDict.keys():

--- a/scripts/pull-public-assets.py
+++ b/scripts/pull-public-assets.py
@@ -43,6 +43,10 @@ def main():
         )
 
         agency_dir = os.path.join(AGENCY_CODEJSON_DIR, args.agency)
+        try:
+            os.mkdir(agency_dir)
+        except FileExistsError:
+            print(f"File already exists: {agency_dir}")
 
         for org in args.orgs.split(","):
             org = org.strip()

--- a/scripts/pull-public-assets.py
+++ b/scripts/pull-public-assets.py
@@ -37,7 +37,7 @@ def main():
 
                 indexGen.save_organization_files(org, agency_dir)
 
-            indexGen.save_index(os.path.join(agency_dir, agency, "_index.json"))
+            indexGen.save_index(os.path.join(agency_dir, agency + "_index.json"))
             print(f"\nIndexing complete. Results saved to {agency_dir}")
         
     except Exception as e:

--- a/scripts/pull-public-assets.py
+++ b/scripts/pull-public-assets.py
@@ -24,27 +24,21 @@ def main():
                 token = github_key
             )
 
-            agency_dir = os.path.join(AGENCY_CODEJSON_DIR, agency)
 
             try:
                 os.mkdir(AGENCY_CODEJSON_DIR)
             except FileExistsError:
                 print(f"File already exists: {AGENCY_CODEJSON_DIR}")
 
-            try:
-                os.mkdir(agency_dir)
-            except FileExistsError:
-                print(f"File already exists: {agency_dir}")
-
             orgs = codegovDict[agency]["orgs"]
             for org in orgs:
                 org = org.strip()
                 indexGen.process_organization(org)
 
-                indexGen.save_organization_files(org, agency_dir)
+                indexGen.save_organization_files(org, AGENCY_CODEJSON_DIR)
 
-            indexGen.save_index(os.path.join(agency_dir, agency + "_index.json"))
-            print(f"\nIndexing complete. Results saved to {agency_dir}")
+            indexGen.save_index(os.path.join(AGENCY_CODEJSON_DIR, agency + "_index.json"))
+            print(f"\nIndexing complete. Results saved to {AGENCY_CODEJSON_DIR}")
         
     except Exception as e:
         print(f"Error: {e}")

--- a/scripts/pull-public-assets.py
+++ b/scripts/pull-public-assets.py
@@ -1,0 +1,61 @@
+import json
+import base64
+import argparse
+import os
+
+from codejson_index_generator import IndexGenerator
+
+AGENCY_CODEJSON_DIR = "agency-indexes"
+
+def main():
+    parser = argparse.ArgumentParser(
+        description = "Create an index of code.json files within agency organizations for code.gov compliance.",
+        epilog = "Examples:"
+               "  python pull-public-assets.py --agency CMS --orgs 'org1,org2' --OR-- "
+               "  python pull-public-assets.py --agency TTS --orgs 'GSA,USDC' --version 2.0.0"
+    )
+
+    parser.add_argument(
+        "--agency", 
+        required = True,
+        help = "Agency name for code.json index creation"
+    )
+    parser.add_argument(
+        "--orgs", 
+        required = True,
+        help = "Comma-separated list of GitHub organizations in your agency"
+    )
+
+    parser.add_argument(
+        "--version", 
+        default = "1.0.0",
+        help = "Code.json file version (e.g., 1.0.0, 2.1.0)"
+    )
+
+    args = parser.parse_args()
+    github_key = os.getenv("GITHUB_KEY")
+
+    try:
+        indexGen = IndexGenerator(
+            agency = args.agency,
+            verison = args.version, 
+            token = github_key
+        )
+
+        agency_dir = os.path.join(AGENCY_CODEJSON_DIR, args.agency)
+
+        for org in args.orgs.split(","):
+            org = org.strip()
+            indexGen.process_organization(org)
+
+            indexGen.save_organization_files(org, agency_dir)
+
+        indexGen.save_index(os.path.join(agency_dir, args.agency, "_index.json"))
+        print(f"\nIndexing complete. Results saved to {agency_dir}")
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        return
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pull-public-assets.py
+++ b/scripts/pull-public-assets.py
@@ -25,6 +25,12 @@ def main():
             )
 
             agency_dir = os.path.join(AGENCY_CODEJSON_DIR, agency)
+
+            try:
+                os.mkdir(AGENCY_CODEJSON_DIR)
+            except FileExistsError:
+                print(f"File already exists: {AGENCY_CODEJSON_DIR}")
+
             try:
                 os.mkdir(agency_dir)
             except FileExistsError:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+codejson-index-generator


### PR DESCRIPTION
## Add Download Job

## Problem

We currently don't automatically download agency codeJSON files and index them to put in the agency-indexes dir

## Solution

Create a Python Script that uses the `codejson-index-generator` library that I uploaded to PyPI that was created by Sachin

## Result

Summary:

* Added a python script called pull-public-assets.py
* Use IndexGenerator class to index and download all code.json files 
* Save files as `<repo_name>.json` for code.json files
* Save indexes as `<agency_name>_index.json` for index files
* Added `fetchAgencyCodeJSON.yml` file to add workflow to run the script
* Added `.venv/` directory to the `.gitignore` file

## Test Plan

Run the script locally by creating a venv and running:

```
    pip install -r scripts/requirements.txt
    python scripts/pull-public-assets.py
```
