### PR TITLE
Guidance section: Updated permalinks

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -5,4 +5,4 @@ codegov:
   - name: Agencies
     url: /agencies/
   - name: Guidance
-    url: /guidance/
+    url: /agency-compliance/compliance/dashboard

--- a/content/guidance/index.md
+++ b/content/guidance/index.md
@@ -1,7 +1,7 @@
 ---
-title: Guidance
+title: Agency Compliance
 description: 'Guidance'
-permalink: /guidance/
+permalink: /agency-compliance/compliance/dashboard
 layout: layouts/page
 tags: codegov
 eleventyNavigation:
@@ -12,5 +12,10 @@ eleventyNavigation:
 sidenav: true
 sticky_sidenav: true
 ---
+Agencies are required to perform various tasks in order to satisfy the objectives of the Federal Source Code Policy. Currently, agencies are evaluated on whether they've completed three tasks:
 
-Agency Compliance
+1. **Updated Agency Policy**: Agencies must update their policies to be consistent with the Federal Source Code Policy.
+2. **Updated Acquisition Language**: Agencies must update acquisition language to capture new custom code whether built by a contractor or federal employee.
+3. **Updated Code Inventory**: Agencies must create and update an agency source code inventory to be placed online on agency website and Code.gov.
+
+Agencies are evaluated as fully compliant (green), partially compliant (yellow), or non-compliant (red) with the tasks outlined above. An agency's overall compliance is green only if they are green in all categories. This is an assessment of agency compliance over the course of the pilot program.

--- a/content/guidance/inventory-code.md
+++ b/content/guidance/inventory-code.md
@@ -1,14 +1,14 @@
 ---
 title: Creating your enterprise code inventory
 description: 'Code Inventory'
-permalink: /guidance/code-inventory/
+permalink: /agency-compliance/compliance/code-inventory/
 layout: layouts/page
 tags: codegov
 eleventyNavigation:
   parent: codegov-guidance
   key: codegov-guidance-codeinventory
   order: 3
-  title: How to inventory code
+  title: How to Inventory Code
 sidenav: true
 sticky_sidenav: true
 ---

--- a/content/guidance/procurement.md
+++ b/content/guidance/procurement.md
@@ -1,14 +1,14 @@
 ---
 title: Building and Buying Custom Software
 description: 'Procurement'
-permalink: /guidance/procurement/
+permalink: /agency-compliance/compliance/procurement/
 layout: layouts/page
 tags: codegov
 eleventyNavigation:
   parent: codegov-guidance
   key: codegov-guidance-procurement
   order: 2
-  title: How to procure software
+  title: How to Procure Software
 sidenav: true
 sticky_sidenav: true
 ---

--- a/index.html
+++ b/index.html
@@ -29,7 +29,8 @@ eleventyExcludeFromCollections: true
       <div class="explore-actions">
         <h2>Developers</h2>
         <p>
-          The Code.gov website is developed publicly on GitHub. Learn how to <a href="https://github.com/GSA/code-gov/blob/master/README.md" target="_blank">contribute here</a>. Help
+          The Code.gov website is developed publicly on GitHub. Learn how to <a
+            href="https://github.com/GSA/code-gov/blob/master/README.md" target="_blank">contribute here</a>. Help
           improve America's Code by exploring projects.
         </p>
         <a class="usa-button" href="/agencies/">Explore projects</a>
@@ -45,7 +46,7 @@ eleventyExcludeFromCollections: true
           Federal agency partners use Code.gov to share usable open source code, promote open source
           projects, and track compliance with federal open source policy.
         </p>
-        <a class="usa-button" href="/guidance/">Agency Compliance</a>
+        <a class="usa-button" href="/agency-compliance/compliance/dashboard">Agency Compliance</a>
       </div>
     </div>
     <div class="grid-row">

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@ eleventyExcludeFromCollections: true
     <div class="grid-row" id="explore-row">
       <div class="explore-actions">
         <h2>Developers</h2>
+          <!-- TODO: Update this link to the current repo. -->
         <p>
           The Code.gov website is developed publicly on GitHub. Learn how to <a
             href="https://github.com/GSA/code-gov/blob/master/README.md" target="_blank">contribute here</a>. Help


### PR DESCRIPTION
## Guidance section: Updated permalinks

## Problem

Currently, not all of the website URLs match the URLs in the original code.gov website.

## Solution

Updated URLs in guidance section:
- `/agency-compliance/compliance/dashboard` for agency compliance page
- `/agency-compliance/compliance/procurement` for software procurement page
- `/agency-compliance/compliance/inventory-code` for code inventory page

## Result

All URLs match original code.gov website

## Test Plan

`npm run dev`

Aside from privacy policy content, passes tests for links and internal-links 