### PR TITLE
Guidance: Updated permalink to add trailing slash

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -5,4 +5,4 @@ codegov:
   - name: Agencies
     url: /agencies/
   - name: Guidance
-    url: /agency-compliance/compliance/dashboard
+    url: /agency-compliance/compliance/dashboard/

--- a/content/guidance/index.md
+++ b/content/guidance/index.md
@@ -1,7 +1,7 @@
 ---
 title: Agency Compliance
 description: 'Guidance'
-permalink: /agency-compliance/compliance/dashboard
+permalink: /agency-compliance/compliance/dashboard/
 layout: layouts/page
 tags: codegov
 eleventyNavigation:


### PR DESCRIPTION
## Guidance: Updated permalink to add trailing slash

## Problem

When I clicked on guidance tab in navigation bar, an HTML file would download instead of taking me to the agency compliance page.

## Solution

- Added trailing slash to guidance section's permalinks

## Result

Guidance tab in Navigation bar directs to agency compliance page

## Test Plan

Tested locally