### PR TITLE
Agencies: Added table of agency liaisons

### DIFF
--- a/.github/ISSUE_TEMPLATE/agency_liaisons.md
+++ b/.github/ISSUE_TEMPLATE/agency_liaisons.md
@@ -1,0 +1,20 @@
+---
+name: Add/Update Agency Liaison
+about: Request to add/update the agency liaison list
+title: '[AGENCY] Add Agency Liaison'
+labels: 'agency-liaison'
+assignees: '@natalialuzuriaga'
+
+---
+
+To request an addition or update to agency liaison information, please fill out the form below. This will update the agency liaison list found in [content/agencies/agency-liaisons.md](https://github.com/DSACMS/code-gov/blob/main/content/agencies/agency-liaisons.md).
+
+**Agency**
+Insert agency here
+
+**Agency Liaison(s) Information**
+Name:
+Email Address:
+
+**Additional context**
+Add any other information about the request.

--- a/.github/ISSUE_TEMPLATE/agency_liaisons.md
+++ b/.github/ISSUE_TEMPLATE/agency_liaisons.md
@@ -1,7 +1,7 @@
 ---
 name: Add/Update Agency Liaison
 about: Request to add/update the agency liaison list
-title: '[AGENCY] Add Agency Liaison'
+title: '[AGENCY] Add/Update Agency Liaison'
 labels: 'agency-liaison'
 assignees: '@natalialuzuriaga'
 

--- a/content/agencies/agency-liaisons.md
+++ b/content/agencies/agency-liaisons.md
@@ -1,0 +1,46 @@
+---
+title: Agency Liaisons
+description: 'List of agency liaisons'
+permalink: /agencies/agency-liaisons
+layout: layouts/page
+tags: codegov
+eleventyNavigation:
+  parent: codegov-agencies
+  key: codegov-agencies-agencyliaisons
+  order: 2
+  title: Agency Liaison
+sidenav: false
+sticky_sidenav: false
+---
+
+Last Updated: 04/03/2024
+
+|Agency   |Liaison(s)   |Email(s)   |
+|---|---|---|
+|Dept. of Agriculture |Alexander Pyle |Alexander.Pyle@ocio.usda.gov, Source.Code@ocio.usda.gov |
+|Dept. of Commerce |Rajeev Sharma |Rajeev.Sharma@doc.gov |
+|Dept. of Defense |Daniel Risacher |daniel.r.risacher.civ@mail.mil |
+|Dept. of Education |William Parker |William.Parker@ed.gov |
+|Dept. of Energy |Denise Hill, Alberto Alvarez, Lance Vowell, Ian Lee |Denise.Hill@hq.doe.gov, alberto.alvarez@hq.doe.gov, vowelll@osti.gov, lee1001@llnl.gov |
+|Dept. of Health and Human Services |Jack Stoute, Domenic Caruano |Jack.Stoute@hhs.gov, Domenic.Caruano@hhs.gov |
+|Dept. of Homeland Security |Stephen Quirolgico, Brian Campo, Eric Ritter, Norman Prentice |stephen.quirolgico@hq.dhs.gov, Brian.Campo@hq.dhs.gov, eric.ritter@hq.dhs.gov, prentice.s.norman@uscis.dhs.gov |
+|Dept. of Housing and Urban Development |Robert Arrington |robert.a.arrington@hud.gov |
+|Dept. of Justice |Russell Washington |russell.washington2@usdoj.gov |
+|Dept. of Labor |Renee Zhao |Zhao.Renee.Y@dol.gov |
+|Dept. of State |Rod Morgan |MorganR@state.gov |
+|Dept. of Interior |Lin Zhang |lin.zhang@ios.doi.gov |
+|Dept. of Treasury |Tony Lu, Rajeev Mishra, Eric Lao, Andrea Miller |tao.lu@treasury.gov, rajeev.mishra@treasury.gov, eric.luo@treasury.gov, andrea.miller@treasury.gov |
+|Dept. of Transportation |Dan Morgan |daniel.morgan@dot.gov |
+|Dept. of Veterans Affairs |Christina VanMetre, Theresa Gainsburg |Christina.Vanmetre@va.gov, Theresa.Gainsburg@va.gov |
+|Environmental Protection Agency |Lico Galindo |Galindo.Lico@epa.gov |
+|General Services Administration |Vicki McFadden |victoria.mcfadden@gsa.gov |
+|National Aeronautics and Space Administration |Travis Kantz |travis.kantz@nasa.gov |
+|National Science Foundation |Elanchezhian Sivagnanam, Garey Taylor, Akhilesh Mathur |esivagna@nsf.gov, gtaylor@associates.nsf.gov, amathur@associates.nsf.gov |
+|Nuclear Regulatory Commission |Arthur Smith |arthur.smith@nrc.gov |
+|Office of Personnel Management |Adrian Lintz |adrian.lintz@opm.gov |
+|Small Business Administration |Andrew Davy, Ryan Hillard |Andrew.Davy@sba.gov, Ryan.Hillard@sba.gov |
+|Social Security Administration |Joseph Amalfitano, Kailash (Kal) Pathak |joseph.amalfitano@ssa.gov, kailash.pathak@ssa.gov |
+|US Agency for International Development |Danny You, Nancy Le |syou@usaid.gov, nle@usaid.gov |
+|National Archives and Records Administration |Mike Senseney |michael.senseney@nara.gov |
+|Consumer Financial Protection Bureau |Scott Cranfill, Adam Scott, William Barton |Scott.Cranfill@cfpb.gov, adam.scott@cfpb.gov, William.Barton@cfpb.gov |
+|Federal Election Commission |Laura Beaufort |lbeaufort@fec.gov |

--- a/content/agencies/agency-liaisons.md
+++ b/content/agencies/agency-liaisons.md
@@ -14,6 +14,7 @@ sticky_sidenav: false
 ---
 
 Last Updated: 04/03/2024
+To request an addition or update to agency liaison information, please submit an [agency liaison issue](https://github.com/DSACMS/gov-codejson/issues) to the repository.
 
 |Agency   |Liaison(s)   |Email(s)   |
 |---|---|---|

--- a/content/agencies/agency-liaisons.md
+++ b/content/agencies/agency-liaisons.md
@@ -1,7 +1,7 @@
 ---
 title: Agency Liaisons
 description: 'List of agency liaisons'
-permalink: /agencies/agency-liaisons
+permalink: /agencies/agency-liaisons/
 layout: layouts/page
 tags: codegov
 eleventyNavigation:


### PR DESCRIPTION
## Agencies: Added table of agency liaisons

## Problem

We would like to add a table of agency liaisons to the repository.

## Solution

- New file created where table lives in `content/agencies/agency-liaisons.md`
- Created an issue template for users to submit request to update agency liaison information

## Result

Once merged to main, the agency liaison web page is now created and found here: https://dsacms.github.io/code-gov/agencies/agency-liaisons/

## Test Plan

npm run dev