### PR TITLE
Home Page: Fixed button urls

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,13 +28,13 @@ eleventyExcludeFromCollections: true
     <div class="grid-row" id="explore-row">
       <div class="explore-actions">
         <h2>Developers</h2>
-          <!-- TODO: Update this link to the current repo. -->
+        <!-- TODO: Update this link to the current repo. -->
         <p>
           The Code.gov website is developed publicly on GitHub. Learn how to <a
             href="https://github.com/GSA/code-gov/blob/master/README.md" target="_blank">contribute here</a>. Help
           improve America's Code by exploring projects.
         </p>
-        <a class="usa-button" href="/agencies/">Explore projects</a>
+        <a class="usa-button" href="{{'/agencies' | url }}">Explore projects</a>
       </div>
       <div class="explore-connect">
         <h2>Connect with Us</h2>
@@ -47,7 +47,7 @@ eleventyExcludeFromCollections: true
           Federal agency partners use Code.gov to share usable open source code, promote open source
           projects, and track compliance with federal open source policy.
         </p>
-        <a class="usa-button" href="/agency-compliance/compliance/dashboard">Agency Compliance</a>
+        <a class="usa-button" href="{{'/agency-compliance/compliance/dashboard' | url }}">Agency Compliance</a>
       </div>
     </div>
     <div class="grid-row">


### PR DESCRIPTION
## Home Page: Fixed button urls

## Problem

On prod, button urls were missing the pathPrefix (dsacms.github.io/agencies vs /code-gov/agencies).

## Solution

Updated the href field to include the url 11ty filter to add the pathPrefix

## Result

Links now direct with pathPrefix (dsacms.github.io/code-gov/)

## Test Plan

npm run dev