### PR TITLE
Home page: Add new links and section content

### DIFF
--- a/_data/navigation.yaml
+++ b/_data/navigation.yaml
@@ -4,6 +4,8 @@ codegov:
     url: /
   - name: Agencies
     url: /agencies/
+  - name: Projects
+    url: /projects/
   - name: Issues
     url: /issues/
   - name: Guidance

--- a/_includes/usa_identifier.html
+++ b/_includes/usa_identifier.html
@@ -18,6 +18,12 @@
       <li
         class="grid-col-12 tablet-lg:grid-col-auto usa-footer__primary-content font-body-3xs margin-bottom-0 border-top-0">
         <a class="usa-footer__primary-link padding-bottom-1 padding-top-0 tablet-lg:padding-y-2 text-base-dark"
+          href="https://github.com/DSACMS/code-gov" target="_blank" rel="noopener noreferrer"><span
+            class="text-base-dark">Repository</span></a>
+      </li>
+      <li
+        class="grid-col-12 tablet-lg:grid-col-auto usa-footer__primary-content font-body-3xs margin-bottom-0 border-top-0">
+        <a class="usa-footer__primary-link padding-bottom-1 padding-top-0 tablet-lg:padding-y-2 text-base-dark"
           href="https://www.gsa.gov/reference/freedom-of-information-act-foia" target="_blank"
           rel="noopener noreferrer"><span class="text-base-dark">FOIA</span></a>
       </li>

--- a/assets/_common/styles/_homepage.scss
+++ b/assets/_common/styles/_homepage.scss
@@ -51,7 +51,7 @@ p {
 }
 
 .explore-actions,
-.explore-connect,
+.explore-inventory,
 .explore-agencies {
   padding: 20px;
   max-width: 320px;
@@ -66,7 +66,7 @@ p {
   }
 }
 
-.explore-connect {
+.explore-inventory {
   border-left: 3px solid rgba(28, 48, 74, 0.3);
   border-right: 3px solid rgba(28, 48, 74, 0.3);
 }

--- a/index.html
+++ b/index.html
@@ -34,12 +34,12 @@ eleventyExcludeFromCollections: true
             href="https://github.com/GSA/code-gov/blob/master/README.md" target="_blank">contribute here</a>. Help
           improve America's Code by exploring projects.
         </p>
-        <a class="usa-button" href="{{'/agencies' | url }}">Explore projects</a>
+        <a class="usa-button" href="{{'/projects' | url }}">Explore projects</a>
       </div>
-      <div class="explore-connect">
-        <h2>Connect with Us</h2>
-        <p>Have questions or feedback? Open an issue on our open source repository.</p>
-        <a class="usa-button" href="https://github.com/DSACMS/code-gov"> View Repository </a>
+      <div class="explore-inventory">
+        <h2>Source Code Inventory</h2>
+        <p>Review source code development across the entire federal government.</p>
+        <a class="usa-button" href="{{'/agencies' | url }}"> View by Agency </a>
       </div>
       <div class="explore-agencies">
         <h2>Agency Partners</h2>
@@ -92,7 +92,8 @@ eleventyExcludeFromCollections: true
             <div class="goal-text">
               <h3>EXPLORE OPPORTUNITIES</h3>
               <p>
-                Search through issues from federal repositories, filter by popularity or difficulty, and find ways to contribute to government open source technology
+                Search through issues from federal repositories, filter by popularity or difficulty, and find ways to
+                contribute to government open source technology
               </p>
             </div>
           </div>
@@ -101,7 +102,7 @@ eleventyExcludeFromCollections: true
             <div class="goal-text">
               <h3>OPT-IN WITH LABELS</h3>
               <p>
-                Repository maintainers can include their projects by adding a <strong>code-gov</strong> label 
+                Repository maintainers can include their projects by adding a <strong>code-gov</strong> label
                 to GitHub issues, making them discoverable to developers ready to contribute
               </p>
             </div>


### PR DESCRIPTION
## Home page: Add new links and section content

## Problem

We would like to update the home page with new links and section content

## Solution

- Removed "View Repository" section and added repository link to footer instead
- Added new "Inventory" section that points to /agencies

## Result

Home page now looks like:
<img width="941" alt="Screenshot 2025-06-25 at 3 26 24 PM" src="https://github.com/user-attachments/assets/634069de-7cf2-471e-b694-2e37641c0057" />

<img width="539" alt="Screenshot 2025-06-25 at 3 26 58 PM" src="https://github.com/user-attachments/assets/32ffcab1-c988-4448-bc0b-21d2d19673df" />

## Test Plan

Tests passed, runs locally `npm run dev`